### PR TITLE
Fix deserializing heterogeneous tuples on Ruby < 3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [".gitignore", ".github"]
 [dependencies]
 serde = "1.0"
 magnus = "0.4"
+tap = "1.0"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/de/array_deserializer.rs
+++ b/src/de/array_deserializer.rs
@@ -1,16 +1,16 @@
-use super::Deserializer;
+use super::{arrays::ArrayEnumerator, Deserializer};
 use crate::error::Error;
-use magnus::{Enumerator, RArray};
+use magnus::RArray;
 use serde::de::{DeserializeSeed, SeqAccess};
 
 pub struct ArrayDeserializer {
-    entries: Enumerator,
+    entries: ArrayEnumerator,
 }
 
 impl ArrayDeserializer {
     pub fn new(array: RArray) -> ArrayDeserializer {
         ArrayDeserializer {
-            entries: array.each(),
+            entries: ArrayEnumerator::new(array),
         }
     }
 }
@@ -24,7 +24,7 @@ impl<'i> SeqAccess<'i> for ArrayDeserializer {
     {
         match self.entries.next() {
             Some(Ok(entry)) => seed.deserialize(Deserializer::new(entry)).map(Some),
-            Some(Err(error)) => Err(Error::from(error)),
+            Some(Err(error)) => Err(error.into()),
             None => Ok(None),
         }
     }

--- a/src/de/arrays.rs
+++ b/src/de/arrays.rs
@@ -1,0 +1,54 @@
+use magnus::{exception, Error, RArray, Value};
+use std::convert::TryInto;
+use tap::TapFallible;
+
+/// For a heterogeneous array, [`magnus::Enumerator::next`] returns an error on Ruby < 3.0:
+///
+/// ```text
+/// #<FiberError: fiber called across stack rewinding barrier>
+/// ```
+///
+/// This was fixed by [ruby/ruby#4606](https://github.com/ruby/ruby/pull/4606).
+///
+/// To appease older Rubies, step through an array by index rather than using a Ruby `Enumerator`.
+///
+/// TODO: remove this when dropping support for Ruby 2.7.
+pub struct ArrayEnumerator {
+    array: RArray,
+    index: isize,
+}
+
+impl ArrayEnumerator {
+    pub fn new(array: RArray) -> ArrayEnumerator {
+        ArrayEnumerator { array, index: 0 }
+    }
+
+    fn peek(&self) -> Result<Option<Value>, Error> {
+        if let Ok(len) = self.array.len().try_into() {
+            if self.index < len {
+                self.array.entry(self.index).map(Some)
+            } else {
+                Ok(None)
+            }
+        } else {
+            Err(Error::new(
+                exception::range_error(),
+                "array length out of range",
+            ))
+        }
+    }
+}
+
+impl Iterator for ArrayEnumerator {
+    type Item = Result<Value, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.peek()
+            .tap_ok(|item| {
+                if item.is_some() {
+                    self.index += 1
+                }
+            })
+            .transpose()
+    }
+}

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,6 +1,7 @@
 mod deserializer;
 
 mod array_deserializer;
+mod arrays;
 mod enum_deserializer;
 mod hash_deserializer;
 mod variant_deserializer;
@@ -188,11 +189,11 @@ use std::ops::Deref;
 /// use serde::Deserialize;
 ///
 /// #[derive(PartialEq, Debug, Deserialize)]
-/// struct Foo(u16, u16, u16);
+/// struct Foo(u16, bool, String);
 ///
-/// let input: Value = eval!("[123, 456, 789]")?;
+/// let input: Value = eval!("[123, true, 'Hello, world!']")?;
 /// let output: Foo = deserialize(&input)?;
-/// assert_eq!(Foo(123, 456, 789), output);
+/// assert_eq!(Foo(123, true, "Hello, world!".into()), output);
 /// #
 /// # Ok::<(), magnus::Error>(())
 /// ```
@@ -231,7 +232,7 @@ use std::ops::Deref;
 /// enum Foo {
 ///     Bar,
 ///     Baz(u16),
-///     Glorp(u16, u16, u16),
+///     Glorp(u16, bool, String),
 ///     Quux {
 ///         frob: u16,
 ///         wally: bool,
@@ -250,16 +251,7 @@ use std::ops::Deref;
 /// # let _cleanup = unsafe { magnus::embed::init() };
 /// #
 /// # #[derive(PartialEq, Debug, Deserialize)]
-/// # enum Foo {
-/// #     Bar,
-/// #     Baz(u16),
-/// #     Glorp(u16, u16, u16),
-/// #     Quux {
-/// #         frob: u16,
-/// #         wally: bool,
-/// #         plugh: String
-/// #     }
-/// # }
+/// # enum Foo { Bar }
 /// #
 /// let input: Value = eval!("'Bar'")?;
 /// let output: Foo = deserialize(&input)?;
@@ -278,16 +270,7 @@ use std::ops::Deref;
 /// # let _cleanup = unsafe { magnus::embed::init() };
 /// #
 /// # #[derive(PartialEq, Debug, Deserialize)]
-/// # enum Foo {
-/// #     Bar,
-/// #     Baz(u16),
-/// #     Glorp(u16, u16, u16),
-/// #     Quux {
-/// #         frob: u16,
-/// #         wally: bool,
-/// #         plugh: String
-/// #     }
-/// # }
+/// # enum Foo { Baz(u16) }
 /// #
 /// let input: Value = eval!("{ 'Baz' => 1234 }")?;
 /// let output: Foo = deserialize(&input)?;
@@ -306,20 +289,11 @@ use std::ops::Deref;
 /// # let _cleanup = unsafe { magnus::embed::init() };
 /// #
 /// # #[derive(PartialEq, Debug, Deserialize)]
-/// # enum Foo {
-/// #     Bar,
-/// #     Baz(u16),
-/// #     Glorp(u16, u16, u16),
-/// #     Quux {
-/// #         frob: u16,
-/// #         wally: bool,
-/// #         plugh: String
-/// #     }
-/// # }
+/// # enum Foo { Glorp(u16, bool, String) }
 /// #
-/// let input: Value = eval!("{ 'Glorp' => [123, 456, 789] }")?;
+/// let input: Value = eval!("{ 'Glorp' => [123, true, 'Hello, world!'] }")?;
 /// let output: Foo = deserialize(&input)?;
-/// assert_eq!(Foo::Glorp(123, 456, 789), output);
+/// assert_eq!(Foo::Glorp(123, true, "Hello, world!".into()), output);
 /// #
 /// # Ok::<(), magnus::Error>(())
 /// ```
@@ -335,9 +309,6 @@ use std::ops::Deref;
 /// #
 /// # #[derive(PartialEq, Debug, Deserialize)]
 /// # enum Foo {
-/// #     Bar,
-/// #     Baz(u16),
-/// #     Glorp(u16, u16, u16),
 /// #     Quux {
 /// #         frob: u16,
 /// #         wally: bool,
@@ -364,6 +335,23 @@ use std::ops::Deref;
 /// ```
 ///
 /// ### Compound types
+///
+/// #### Tuples
+///
+/// ```
+/// # use magnus::{eval, Value};
+/// # use serde_magnus::deserialize;
+/// #
+/// # let _cleanup = unsafe { magnus::embed::init() };
+/// #
+/// let input: Value = eval!("[123, true, 'Hello, world!']")?;
+/// let output: (i16, bool, String) = deserialize(&input)?;
+/// assert_eq!((123, true, "Hello, world!".into()), output);
+/// #
+/// # Ok::<(), magnus::Error>(())
+/// ```
+///
+/// #### Arrays
 ///
 /// ```
 /// # use magnus::{eval, Value};

--- a/tests/deserializing_enums.rs
+++ b/tests/deserializing_enums.rs
@@ -1,4 +1,4 @@
-use magnus::{Error, RHash, RString, Symbol};
+use magnus::{Error, RArray, RHash, RString, Symbol};
 use serde::Deserialize;
 use serde_magnus::deserialize;
 
@@ -6,7 +6,8 @@ use serde_magnus::deserialize;
 enum A {
     A,
     B(u64),
-    C { message: String },
+    C(u64, bool, String),
+    D { message: String },
 }
 
 #[test]
@@ -23,15 +24,26 @@ fn test_deserializing_enums() -> Result<(), Error> {
     let output: A = deserialize(input)?;
     assert_eq!(A::B(123), output);
 
-    let value = RHash::new();
-    value.aset(Symbol::new("message"), "Hello, world!")?;
+    let value = RArray::new();
+    value.push(1234)?;
+    value.push(true)?;
+    value.push("Hello, world!")?;
 
     let input = RHash::new();
     input.aset("C", value)?;
 
+    let output: A = deserialize(input).unwrap();
+    assert_eq!(A::C(1234, true, "Hello, world!".into()), output);
+
+    let value = RHash::new();
+    value.aset(Symbol::new("message"), "Hello, world!")?;
+
+    let input = RHash::new();
+    input.aset("D", value)?;
+
     let output: A = deserialize(input)?;
     assert_eq!(
-        A::C {
+        A::D {
             message: "Hello, world!".into()
         },
         output

--- a/tests/deserializing_structs.rs
+++ b/tests/deserializing_structs.rs
@@ -1,4 +1,4 @@
-use magnus::{Error, Integer, RHash, Symbol, QNIL};
+use magnus::{Error, Integer, RArray, RHash, RString, Symbol, QNIL, QTRUE};
 use serde::Deserialize;
 use serde_magnus::deserialize;
 
@@ -9,7 +9,10 @@ struct A;
 struct B(u64);
 
 #[derive(Deserialize, PartialEq, Debug)]
-struct C {
+struct C(u64, bool, String);
+
+#[derive(Deserialize, PartialEq, Debug)]
+struct D {
     message: String,
 }
 
@@ -23,12 +26,20 @@ fn test_deserializing_structs() -> Result<(), Error> {
     let output: B = deserialize(input)?;
     assert_eq!(B(123), output);
 
+    let input = RArray::new();
+    input.push(Integer::from_u64(123))?;
+    input.push(QTRUE)?;
+    input.push(RString::from("Hello, world!"))?;
+
+    let output: C = deserialize(input)?;
+    assert_eq!(C(123, true, "Hello, world!".into()), output);
+
     let input = RHash::new();
     input.aset(Symbol::new("message"), "Hello, world!")?;
 
-    let output: C = deserialize(input)?;
+    let output: D = deserialize(input)?;
     assert_eq!(
-        C {
+        D {
             message: "Hello, world!".into()
         },
         output

--- a/tests/deserializing_tuples.rs
+++ b/tests/deserializing_tuples.rs
@@ -1,4 +1,4 @@
-use magnus::{Error, Integer, RArray, QNIL};
+use magnus::{Error, Integer, RArray, RString, QNIL, QTRUE};
 use serde_magnus::deserialize;
 
 #[test]
@@ -8,12 +8,12 @@ fn test_deserializing_tuples() -> Result<(), Error> {
     assert_eq!((), deserialize(QNIL)?);
 
     let input: RArray = RArray::new();
-    input.push(Integer::from_i64(1))?;
-    input.push(Integer::from_i64(2))?;
-    input.push(Integer::from_i64(3))?;
+    input.push(Integer::from_i64(123))?;
+    input.push(QTRUE)?;
+    input.push(RString::from("Hello, world!"))?;
 
-    let output: (i64, i64, i64) = deserialize(input)?;
-    assert_eq!((1, 2, 3), output);
+    let output: (i64, bool, String) = deserialize(input)?;
+    assert_eq!((123, true, "Hello, world!".into()), output);
 
     Ok(())
 }


### PR DESCRIPTION
For a heterogeneous array, [`magnus::Enumerator::next`](https://docs.rs/magnus/latest/magnus/struct.Enumerator.html#method.next) returns an error on Ruby < 3.0:

```
#<FiberError: fiber called across stack rewinding barrier>
```

This was fixed by [ruby/ruby#4606](https://github.com/ruby/ruby/pull/4606).

To appease older Rubies, step through an array by index rather than using a Ruby `Enumerator`.